### PR TITLE
Added conditional include of hot-reloading for release.

### DIFF
--- a/server/config/config.js.dist
+++ b/server/config/config.js.dist
@@ -1,4 +1,5 @@
 module.exports = {
+  dev: true,
   mongodb: {
     host: 'localhost',
     port: 27017,

--- a/server/index.js
+++ b/server/index.js
@@ -1,25 +1,33 @@
-/* eslint-disable import/no-extraneous-dependencies */
-const webpack = require('webpack');
-const webpackConfig = require('./config/webpack.config.dev');
-const webpackDevMiddleware = require('webpack-dev-middleware');
-const webpackHotMiddleware = require('webpack-hot-middleware');
 const express = require('express');
 const bodyParser = require('body-parser');
 const players = require('./api/players');
 const scorepads = require('./api/scorepads');
+const config = require('./config/config');
 
-const compiler = webpack(webpackConfig);
 const app = express();
+
+
+if (config.dev) {
+  /* eslint-disable global-require,import/no-extraneous-dependencies */
+  const webpack = require('webpack');
+  const webpackConfig = require('./config/webpack.config.dev');
+  const webpackDevMiddleware = require('webpack-dev-middleware');
+  const webpackHotMiddleware = require('webpack-hot-middleware');
+  /* eslint-enable global-require,import/no-extraneous-dependencies */
+
+  const compiler = webpack(webpackConfig);
+
+  app.use(webpackDevMiddleware(compiler, {
+    publicPath: webpackConfig.output.publicPath
+  }));
+
+  app.use(webpackHotMiddleware(compiler));
+}
 
 // we increase the body limit here to allow bigger images in profile picture uploads
 // in the future we probably want to scale the images before uploading them
 app.use(bodyParser.json({ limit: '15mb' }));
 
-app.use(webpackDevMiddleware(compiler, {
-  publicPath: webpackConfig.output.publicPath
-}));
-
-app.use(webpackHotMiddleware(compiler));
 
 app.use('/', express.static('web', {
   index: 'doppelkopf.html'


### PR DESCRIPTION
Vorbereitung aufs Release - das sind nur paar kleine Änderungen in den Server-Einstellungen, damit wir die ganzen Dev-Tools (z.B. Hot Reloading, Source Maps) dort abschalten, weil das im Production-Mode einfach keinen Sinn macht und auch die Performance drosselt (da haben wir ja eh keine Probleme momentan, aber ist trotzdem einfach unsinnig sonst).

**WICHTIG**: Damit das bei dir weiterhin mit den DevTools läuft, musst du unbedingt `dev: true` in deine `/config/config.js` eintragen! Unten steht es schon in der `config.js.dist`, aber das ist nur die Beispielsdatei - du musst es bei dir lokal noch übernehmen.