### PR TITLE
Added mechanism to push JanK terms to each of the players.

### DIFF
--- a/server/db/Model.js
+++ b/server/db/Model.js
@@ -73,14 +73,35 @@ Model.prototype.findBy = function (field, value, onResult) {
  */
 Model.prototype.findOne = function (id, onResult) {
   this.withCollection((collection) => {
-    collection.findOne({
-      _id: ObjectID(id)
-    }, (error, doc) => {
+    collection.findOne(
+      {
+        _id: ObjectID(id)
+      },
+      (error, doc) => {
+        if (error) {
+          throw error;
+        }
+
+        onResult(doc);
+      }
+    );
+  });
+};
+
+/**
+ * Gets the requested number of random elements from this model's collection.
+ *
+ * @param {number} size the size of the result collection, i.e. the number of random elements to get
+ * @param {function} onResult the callback to execute with the list of random results
+ */
+Model.prototype.getRandom = function (size, onResult) {
+  this.withCollection((collection) => {
+    collection.aggregate([{ $sample: { size } }]).toArray((error, result) => {
       if (error) {
         throw error;
       }
 
-      onResult(doc);
+      onResult(result);
     });
   });
 };
@@ -112,17 +133,21 @@ Model.prototype.insertOne = function (doc, onResult) {
  */
 Model.prototype.updateOne = function (id, update, onResult) {
   this.withCollection((collection) => {
-    collection.updateOne({
-      _id: ObjectID(id)
-    }, {
-      $set: update
-    }, (error, result) => {
-      if (error) {
-        throw error;
-      }
+    collection.updateOne(
+      {
+        _id: ObjectID(id)
+      },
+      {
+        $set: update
+      },
+      (error, result) => {
+        if (error) {
+          throw error;
+        }
 
-      onResult(result.result.n > 0);
-    });
+        onResult(result.result.n > 0);
+      }
+    );
   });
 };
 
@@ -134,15 +159,18 @@ Model.prototype.updateOne = function (id, update, onResult) {
  */
 Model.prototype.deleteOne = function (id, onResult) {
   this.withCollection((collection) => {
-    collection.deleteOne({
-      _id: ObjectID(id)
-    }, (error, result) => {
-      if (error) {
-        throw error;
-      }
+    collection.deleteOne(
+      {
+        _id: ObjectID(id)
+      },
+      (error, result) => {
+        if (error) {
+          throw error;
+        }
 
-      onResult(result.deletedCount > 0);
-    });
+        onResult(result.deletedCount > 0);
+      }
+    );
   });
 };
 

--- a/server/db/jank/terms.js
+++ b/server/db/jank/terms.js
@@ -12,6 +12,29 @@ function get(onResult) {
 }
 
 /**
+ * Gets a list of random terms for the specified scorepad.
+ *
+ * @param {Object} scorepad the scorepad to get terms for
+ * @param {function} onResult the callback to execute with the list of terms
+ */
+function getForScorepad(scorepad, onResult) {
+  const nrOfPlayers = scorepad.players.length;
+
+  let nrOfJokers;
+
+  if (nrOfPlayers === 4) {
+    nrOfJokers = 0;
+  } else if (nrOfPlayers % 2 === 1) {
+    nrOfJokers = 1;
+  } else {
+    nrOfJokers = Math.random() > 0.5 ? 2 : 0;
+  }
+
+  const limit = (nrOfPlayers - nrOfJokers) / 2;
+  termModel.getRandom(limit, onResult);
+}
+
+/**
  * Finds a single term by its value.
  *
  * @param {string} value the value of the term to find
@@ -65,5 +88,6 @@ function deleteById(id, onResult) {
 }
 
 exports.get = get;
+exports.getForScorepad = getForScorepad;
 exports.add = add;
 exports.deleteById = deleteById;

--- a/server/game/JanKGame.js
+++ b/server/game/JanKGame.js
@@ -1,8 +1,19 @@
+const terms = require('../db/jank/terms');
+
+/**
+ * The term used for joker players.
+ */
+const JOKER_TERM = '?JOKER?';
+
 /**
  * Creates a new JanK game that several players can connect to through web sockets.
+ *
+ * @param {Object} scorepad the scorepad the game is created for
  */
-function JanKGame() {
+function JanKGame(scorepad) {
+  this.scorepad = scorepad;
   this.sockets = {};
+  this.termMap = {};
 }
 
 /**
@@ -36,6 +47,50 @@ JanKGame.prototype.addConnection = function (playerId, socket) {
   });
 
   this.sockets[playerId] = socket;
+
+  if (playerId in this.termMap) {
+    socket.send('term', this.termMap[playerId].value);
+  } else {
+    this.initTerms();
+  }
+};
+
+/**
+ * Initializes the terms for each player and sends the terms to already connected players.
+ *
+ * Other players will have their terms sent to them upon connection (i.e. in `addConnection()`).
+ */
+JanKGame.prototype.initTerms = function () {
+  if (this.isInitialized) {
+    return;
+  }
+
+  this.isInitialized = true;
+
+  terms.getForScorepad(this.scorepad, (nextTerms) => {
+    let { players } = this.scorepad;
+    const getRandomPlayer = () => {
+      const index = Math.floor(Math.random() * Math.floor(players.length));
+      const player = players[index];
+      players = players.filter(p => p !== player);
+      return player;
+    };
+    const addTerm = (player, term) => {
+      const playerId = player._id.valueOf();
+      this.termMap[playerId] = term;
+
+      if (playerId in this.sockets) {
+        this.sockets[playerId].send('term', term.value);
+      }
+    };
+    nextTerms.forEach((term) => {
+      addTerm(getRandomPlayer(), term);
+      addTerm(getRandomPlayer(), term);
+    });
+
+    // these players didn't get a term -> they are jokers
+    players.forEach(p => addTerm(p, { value: JOKER_TERM }));
+  });
 };
 
 /**

--- a/src/css/jank/match.css
+++ b/src/css/jank/match.css
@@ -1,3 +1,7 @@
+.term {
+  text-transform: capitalize;
+}
+
 .word-form fieldset {
   border: 0;
 }

--- a/src/jank/match.js
+++ b/src/jank/match.js
@@ -153,6 +153,8 @@ function handleMessage(message) {
   } else if (type === 'word') {
     const { playerId, word } = payload;
     addWord(playerId, word);
+  } else if (type === 'term') {
+    document.getElementById('term-header').textContent = payload;
   }
 }
 
@@ -217,7 +219,7 @@ window.onload = () => {
     scorepad.players.forEach((player) => {
       if (player._id === activePlayerId) {
         const headerText = `Hallo ${player.name}, schön dass du dabei bist!`;
-        document.getElementById('header').textContent = headerText;
+        document.getElementById('player-header').textContent = headerText;
       }
 
       addPlayer(player);

--- a/web/jank/match.html
+++ b/web/jank/match.html
@@ -11,7 +11,11 @@
       <a href="/">Zurück zur Startseite</a>
       <a id="selection-link" href="/">Zurück zur Spielerauswahl</a>
     </div>
-    <h1 id="header"></h1>
+    <h1 id="player-header"></h1>
+    <h1>
+      Dein Begriff diese Runde lautet:
+      <span id="term-header" class="term"></span>
+    </h1>
     <form id="word-form" class="word-form word-text">
       <fieldset name="fields" disabled>
         <label for="word">Dein Wort:</label>


### PR DESCRIPTION
Hiermit werden Spielern Begriffe aus der `terms` Collection (also Tabelle) zugewiesen, und dann über die WebSockets verschickt. Es wird schon beachtet, dass immer 2 Spieler den gleichen Begriff bekommen, und dass es bei entsprechender Spieleranzahl auch 1 bzw. 2 Joker gibt. Die Begriffe werden bereits zufällig ausgewählt, aber noch nicht für das Scorepad gespeichert.