### PR TITLE
Added state handling for different JanK game states.

### DIFF
--- a/src/css/jank/match.css
+++ b/src/css/jank/match.css
@@ -2,26 +2,27 @@
   text-transform: capitalize;
 }
 
-.word-form fieldset {
+.match-form fieldset {
   border: 0;
 }
 
-.word-text {
+.match-text {
   font-size: large;
 }
 
-.word-table {
+.match-table {
   border-collapse: collapse;
   margin-top: 20px;
   width: 100%;
 }
 
-.word-table td,
-.word-table th {
+.match-table td,
+.match-table th {
   border: 2px solid black;
   margin: 0;
   padding: 10px 15px;
   text-align: center;
+  text-transform: capitalize;
 }
 
 .player-picture {

--- a/src/utils/PlayerSelectHelper.js
+++ b/src/utils/PlayerSelectHelper.js
@@ -102,4 +102,22 @@ PlayerSelectHelper.prototype.checkOptions = function () {
   });
 };
 
+/**
+ * Resets the select elements and enables all the options again.
+ *
+ * The action button will be disabled.
+ */
+PlayerSelectHelper.prototype.reset = function () {
+  /* eslint-disable no-param-reassign */
+  this.selects.forEach((select) => {
+    select.selectedIndex = -1;
+
+    Array.from(select.options).forEach((option) => {
+      option.disabled = false;
+    });
+  });
+
+  this.actionButton.disabled = true;
+};
+
 export default PlayerSelectHelper;

--- a/src/utils/getScorepads.js
+++ b/src/utils/getScorepads.js
@@ -33,11 +33,6 @@ function addScorepad(scorepad, scorepadList, onLoad) {
   const listItem = document.createElement('li');
   listItem.className = 'scorepad';
 
-  const game = document.createElement('span');
-  game.className = 'game';
-  game.appendChild(document.createTextNode(scorepad.game));
-  listItem.appendChild(game);
-
   scorepad.players.forEach((player) => {
     listItem.appendChild(createPlayerElement(player));
   });

--- a/web/jank/match.html
+++ b/web/jank/match.html
@@ -12,26 +12,38 @@
       <a id="selection-link" href="/">Zurück zur Spielerauswahl</a>
     </div>
     <h1 id="player-header"></h1>
-    <h1>
+    <h2>
       Dein Begriff diese Runde lautet:
       <span id="term-header" class="term"></span>
-    </h1>
-    <form id="word-form" class="word-form word-text">
+    </h2>
+    <form id="word-form" class="match-form match-text">
       <fieldset name="fields" disabled>
-        <label for="word">Dein Wort:</label>
-        <input class="word-text" name="word" />
-        <button class="word-text" type="submit">abschicken</button>
+        <label for="word">Was ist dein nächstes Wort?</label>
+        <input class="match-text" name="word" />
+        <button class="match-text" type="submit">abschicken</button>
       </fieldset>
     </form>
-    <div>
-      <table id="word-table" class="word-table word-text">
-        <tr>
-          <th>Spieler</th>
-          <th>1. Wort</th>
-          <th>2. Wort</th>
-          <th>Partner</th>
-        </tr>
-      </table>
-    </div>
+    <table id="match-table" class="match-table match-text">
+      <tr>
+        <th>Spieler</th>
+        <th>1. Wort</th>
+        <th>2. Wort</th>
+        <th>Begriff</th>
+      </tr>
+    </table>
+
+    <h2>Hier wird geraten</h2>
+    <form id="bets-form" class="match-form match-text">
+      <fieldset name="fields" disabled>
+        <label for="bet">Auf welches Paar möchtest du tippen?</label>
+        <select class="match-text" name="first"></select>
+        <select class="match-text" name="second"></select>
+        <button id="bets-button" class="match-text" type="submit">
+          abschicken
+        </button>
+      </fieldset>
+    </form>
+    <h2>Deine bisherigen Tipps</h2>
+    <ul id="bets-list"></ul>
   </body>
 </html>


### PR DESCRIPTION
Mit dieser Änderung wir der momentane State vom Spiel auf dem Server gehalten und dann auch an die Spieler, die dem Spiel erst später beitreten kommuniziert.

Mit dieser Änderung können Spieler durch alle Stadien des Spiels wandern:
LOADING -> Begriffe werden an die Spieler verteilt ->
WORDS -> Spieler dürfen ihr erstes Wort vergeben ->
BETS -> Spieler dürfen ihren ersten Tipp abgeben ->
WORDS -> Spieler dürfen ihr zweites Wort vergeben ->
BETS -> Spieler dürfen ihren zweiten Tipp abgeben ->
PAYOUT -> Die Begriffe werden aufgelöst

An letzter Stelle müsste dann noch die Punkteberechnung erfolgen, aber das passiert in diesem Branch noch nicht.