### PR TITLE
Cleaned up CSS for JanK games.

### DIFF
--- a/server/db/jank/terms.js
+++ b/server/db/jank/terms.js
@@ -25,7 +25,11 @@ function getForScorepad(scorepad, onResult) {
   if (nrOfPlayers === 4) {
     nrOfJokers = 0;
   } else if (nrOfPlayers % 2 === 1) {
-    nrOfJokers = 1;
+    if (nrOfPlayers > 6) {
+      nrOfJokers = Math.random() > 0.5 ? 3 : 1;
+    } else {
+      nrOfJokers = 1;
+    }
   } else {
     nrOfJokers = Math.random() > 0.5 ? 2 : 0;
   }

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -28,9 +28,17 @@
 }
 
 .scorepad {
-  width: 90%;
-  display: flex;
   align-items: center;
-  justify-content: space-evenly;
-  margin: 15px 0;
+  border-color: gray;
+  border-style: solid;
+  border-width: 2px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  margin: 5px;
+  padding: 0 5px;
+}
+
+.scorepad .player {
+  margin: 5px;
 }

--- a/src/css/jank/index.css
+++ b/src/css/jank/index.css
@@ -1,11 +1,11 @@
-.player {
+.player-select {
   margin: 20px;
 }
 
-.player select {
+.player-select select {
   margin-right: 15px;
 }
 
-.player button {
+.player-select button {
   margin-left: 15px;
 }

--- a/src/css/jank/match.css
+++ b/src/css/jank/match.css
@@ -30,7 +30,7 @@
 .match-table th {
   border: 2px solid black;
   margin: 0;
-  padding: 10px 15px;
+  padding: 5px;
   text-align: center;
   text-transform: capitalize;
 }
@@ -41,6 +41,17 @@
 
 .player-picture {
   vertical-align: middle;
+  border-width: 5px;
+  border-color: gray;
+  border-style: solid;
+}
+
+.connected .player-picture {
+  border-color: green;
+}
+
+.disconnected .player-picture {
+  border-color: red;
 }
 
 .score {

--- a/src/jank/index.js
+++ b/src/jank/index.js
@@ -40,7 +40,7 @@ function addPlayerSelect() {
   const selectionContainer = document.getElementById('player-selection');
 
   const container = document.createElement('div');
-  container.className = 'player';
+  container.className = 'player player-select';
 
   const select = document.createElement('select');
   container.appendChild(select);

--- a/src/jank/match.js
+++ b/src/jank/match.js
@@ -218,7 +218,7 @@ function onConnected(playerId) {
   const cell = playerCells[playerId];
 
   if (cell) {
-    cell.player.style.background = 'green';
+    cell.player.className = 'connected';
   }
 }
 
@@ -233,7 +233,7 @@ function onDisconnected(playerId) {
   const cell = playerCells[playerId];
 
   if (cell) {
-    cell.player.style.background = 'red';
+    cell.player.className = 'disconnected';
   }
 }
 


### PR DESCRIPTION
Noch ein paar Feinschliffe in CSS:
* Dynamische Anpassung der Spieler-Aufteilung beim Laden eines Spiels (sonst kann es bei zu vielen Spielern passieren, dass die "Spiel laden" und "Spiel löschen" Buttons verschwinden)
* Hintegrundfarbe bei Connect/Disconnect in JanK entfernt, stattdessen Rahmen für Profilbilder
* kleiner Anpassungen an Abständen, Breite usw.